### PR TITLE
fix strict error on mysql TEXT cannot have default value

### DIFF
--- a/upload/modules/miniform/install.php
+++ b/upload/modules/miniform/install.php
@@ -47,7 +47,7 @@ $database->query("DROP TABLE IF EXISTS `".TABLE_PREFIX."mod_miniform_data`");
 $mod_miniformdata = 'CREATE TABLE IF NOT EXISTS `'.TABLE_PREFIX.'mod_miniform_data` ('
 	. ' `message_id` INT NOT NULL NOT NULL auto_increment,'
 	. ' `section_id` INT NOT NULL DEFAULT \'0\','
-	. ' `data` TEXT NOT NULL DEFAULT \'\',' 
+	. ' `data` TEXT NULL,'
 	. ' `submitted_when` INT NOT NULL DEFAULT \'0\',' 
 	. ' PRIMARY KEY ( `message_id` ) '
 	. ' )';


### PR DESCRIPTION
If mysql is in strict mode it throw an error because TEXT/BLOB cannot have default value
In other hand its a good optimisation if i understand the mysql documentation:
http://dev.mysql.com/doc/refman/5.0/en/blob.html

```
Each BLOB or TEXT value is represented internally by a separately allocated object. This is in contrast to all other data types, for which storage is allocated once per column when the table is opened.
```